### PR TITLE
Avoid unnecessary work while updating the texture

### DIFF
--- a/android/src/main/kotlin/com/felipecsl/knes/GLSprite.kt
+++ b/android/src/main/kotlin/com/felipecsl/knes/GLSprite.kt
@@ -10,7 +10,6 @@ import java.nio.IntBuffer
 class GLSprite {
   private var context: RenderContext? = null
   private var texture: Int? = null
-  private var initialized = false
 
   var director: Director? = null
 
@@ -68,36 +67,31 @@ class GLSprite {
           shaderProgram = program
       )
     }
+
+    glBindTexture(GL_TEXTURE_2D, texture!!)
+    glTexImage2D(GL_TEXTURE_2D, 0, GLES11Ext.GL_BGRA, IMG_WIDTH, IMG_HEIGHT, 0,
+              GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, null)
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+
+    // Use our shader program
+    val context = context!!
+    glUseProgram(context.shaderProgram)
+    // Disable blending
+    glDisable(GL_BLEND)
+    // Set the vertex attributes
+    glVertexAttribPointer(context.texCoordHandle, 2, GL_FLOAT, false, 0, context.texVertices)
+    glEnableVertexAttribArray(context.texCoordHandle)
+    glVertexAttribPointer(context.posCoordHandle, 2, GL_FLOAT, false, 0, context.posVertices)
+    glEnableVertexAttribArray(context.posCoordHandle)
   }
 
   private fun updateTexture(image: IntArray) {
-    val buffer = IntBuffer.wrap(image)
-    glBindTexture(GL_TEXTURE_2D, texture!!)
-    if (!initialized) {
-      initialized = true
-      glTexImage2D(GL_TEXTURE_2D, 0, GLES11Ext.GL_BGRA, IMG_WIDTH, IMG_HEIGHT, 0,
-              GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
-
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
-      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
-
-      // Use our shader program
-      val context = context!!
-      glUseProgram(context.shaderProgram)
-      // Disable blending
-      glDisable(GL_BLEND)
-      // Set the vertex attributes
-      glVertexAttribPointer(context.texCoordHandle, 2, GL_FLOAT, false, 0, context.texVertices)
-      glEnableVertexAttribArray(context.texCoordHandle)
-      glVertexAttribPointer(context.posCoordHandle, 2, GL_FLOAT, false, 0, context.posVertices)
-      glEnableVertexAttribArray(context.posCoordHandle)
-    } else {
-      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, IMG_WIDTH, IMG_HEIGHT,
-              GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
-    }
-
+    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, IMG_WIDTH, IMG_HEIGHT,
+            GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, IntBuffer.wrap(image))
     // Draw!
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4)
   }

--- a/android/src/main/kotlin/com/felipecsl/knes/GLSprite.kt
+++ b/android/src/main/kotlin/com/felipecsl/knes/GLSprite.kt
@@ -10,6 +10,8 @@ import java.nio.IntBuffer
 class GLSprite {
   private var context: RenderContext? = null
   private var texture: Int? = null
+  private var initialized = false
+
   var director: Director? = null
 
   data class RenderContext(
@@ -68,33 +70,34 @@ class GLSprite {
     }
   }
 
-  private fun createTexture(image: IntArray): IntBuffer {
+  private fun updateTexture(image: IntArray) {
     val buffer = IntBuffer.wrap(image)
     glBindTexture(GL_TEXTURE_2D, texture!!)
-    glTexImage2D(GL_TEXTURE_2D, 0, GLES11Ext.GL_BGRA, IMG_WIDTH, IMG_HEIGHT, 0,
-        GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
-    // Use our shader program
-    val context = context!!
-    glUseProgram(context.shaderProgram)
-    // Disable blending
-    glDisable(GL_BLEND)
-    // Set the vertex attributes
-    glVertexAttribPointer(context.texCoordHandle, 2, GL_FLOAT, false, 0, context.texVertices)
-    glEnableVertexAttribArray(context.texCoordHandle)
-    glVertexAttribPointer(context.posCoordHandle, 2, GL_FLOAT, false, 0, context.posVertices)
-    glEnableVertexAttribArray(context.posCoordHandle)
-    return buffer
-  }
+    if (!initialized) {
+      initialized = true
+      glTexImage2D(GL_TEXTURE_2D, 0, GLES11Ext.GL_BGRA, IMG_WIDTH, IMG_HEIGHT, 0,
+              GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
 
-  private fun updateTexture(image: IntArray) {
-    val buffer = createTexture(image)
-    glBindTexture(GL_TEXTURE_2D, texture!!)
-    glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, IMG_WIDTH, IMG_HEIGHT,
-        GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST)
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST)
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE)
+      glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE)
+
+      // Use our shader program
+      val context = context!!
+      glUseProgram(context.shaderProgram)
+      // Disable blending
+      glDisable(GL_BLEND)
+      // Set the vertex attributes
+      glVertexAttribPointer(context.texCoordHandle, 2, GL_FLOAT, false, 0, context.texVertices)
+      glEnableVertexAttribArray(context.texCoordHandle)
+      glVertexAttribPointer(context.posCoordHandle, 2, GL_FLOAT, false, 0, context.posVertices)
+      glEnableVertexAttribArray(context.posCoordHandle)
+    } else {
+      glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, IMG_WIDTH, IMG_HEIGHT,
+              GLES11Ext.GL_BGRA, GL_UNSIGNED_BYTE, buffer)
+    }
+
     // Draw!
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4)
   }


### PR DESCRIPTION
Hi! thanks for this repo, I'm learning a lot just by playing around with your code.

I believe this PR avoids some unnecessary work around `updateTexture`. If I understand correctly the texture gets set-up and updated twice on every `draw` call. 
There's the possibility that I'm completely wrong as I'm not *that* familiar with OpenGL (learning it though)

more info here: https://www.khronos.org/opengl/wiki/Common_Mistakes#Updating_a_texture
and here:
https://stackoverflow.com/questions/2405734/difference-between-gltexsubimage-and-glteximage-function-in-opengl